### PR TITLE
firestore の複合インデックス対応（自分のレコードのみ参照＋投稿降順化）

### DIFF
--- a/components/ContributeTable.vue
+++ b/components/ContributeTable.vue
@@ -48,7 +48,7 @@ export default {
     }
   },
   created() {
-    this.initialize()
+    this.initialize(this.currentUser.uid)
   },
   methods: {
     ...mapActions('contributes', ['initialize', 'delete']),

--- a/store/contributes.js
+++ b/store/contributes.js
@@ -17,8 +17,14 @@ export const mutations = {
 }
 
 export const actions = {
-  initialize: firebaseAction(async ({ bindFirebaseRef }) => {
-    await bindFirebaseRef('contributes', contributesRef.orderBy('at', 'desc'))
+  initialize: firebaseAction(async ({ bindFirebaseRef }, uid) => {
+    await bindFirebaseRef(
+      'contributes',
+      contributesRef
+        .where('uid', '==', uid)
+        .orderBy('at', 'desc')
+        .orderBy('created', 'desc')
+    )
   }),
   add: firebaseAction((context, data) => {
     contributesRef.add({


### PR DESCRIPTION
ちゃんと投稿した順序に並ぶようにする。
