### PR TITLE
認証の必要性は router.meta を参照するようにした

### DIFF
--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -1,22 +1,18 @@
 import auth from '~/plugins/auth'
 
-export default async function({ store, route, redirect }) {
+export default async ({ store, route, redirect }) => {
   if (!store.getters['auth/isAuthenticated']) {
     const user = await auth()
     if (user) store.commit('auth/setUser', user)
   }
 
-  const isIgnoreAuthenticated = () =>
-    ['/sign-in', '/sign-up', '/sign-up/verify', '/readonly'].includes(
-      route.path
-    )
-  if (!store.getters['auth/isAuthenticated'] && !isIgnoreAuthenticated()) {
+  const ignoreAuth = route.meta.some(meta => meta.ignoreAuth)
+  if (!store.getters['auth/isAuthenticated'] && !ignoreAuth) {
     return redirect('/sign-in')
   }
 
-  const isRefusalAuthenticated = () =>
-    ['/sign-in', '/sign-up'].includes(route.path)
-  if (store.getters['auth/isAuthenticated'] && isRefusalAuthenticated()) {
+  const rejectedCertified = route.meta.some(meta => meta.rejectedCertified)
+  if (store.getters['auth/isAuthenticated'] && rejectedCertified) {
     return redirect('/')
   }
 }

--- a/pages/readonly/index.vue
+++ b/pages/readonly/index.vue
@@ -18,6 +18,9 @@
 import { mapGetters, mapActions } from 'vuex'
 
 export default {
+  meta: {
+    ignoreAuth: true
+  },
   validate({ query }) {
     return query.uid && query.from && query.to
   },

--- a/pages/sign-in/index.vue
+++ b/pages/sign-in/index.vue
@@ -22,6 +22,10 @@
 import { mapGetters, mapActions } from 'vuex'
 
 export default {
+  meta: {
+    ignoreAuth: true,
+    rejectedCertified: true
+  },
   data() {
     return {
       email: '',

--- a/pages/sign-up/index.vue
+++ b/pages/sign-up/index.vue
@@ -23,6 +23,10 @@
 import { mapGetters, mapActions } from 'vuex'
 
 export default {
+  meta: {
+    ignoreAuth: true,
+    rejectedCertified: true
+  },
   data() {
     const requiredRules = [v => !!v || 'Required field.']
 

--- a/pages/sign-up/verify.vue
+++ b/pages/sign-up/verify.vue
@@ -10,3 +10,12 @@
               .subheading Account registration has not completed yet.
               .subheading Please access the authentication link in the confirmation email sent and complete the authentication.
 </template>
+
+<script>
+export default {
+  meta: {
+    ignoreAuth: true,
+    rejectedCertified: true
+  }
+}
+</script>


### PR DESCRIPTION
いつまでも `middleware/authenticated.js` に書き続けるのは、手続き的で良くない。
宣言的におこなうため、router.meta を参照するようにした。
