### PR TITLE
メールアドレスの変更機能を実装

### DIFF
--- a/components/SettingChangeEmail.vue
+++ b/components/SettingChangeEmail.vue
@@ -1,0 +1,61 @@
+<template lang="pug">
+  v-card.elevation-1
+    v-toolbar(dark flat color="primary")
+      v-toolbar-title Change Email
+    v-form(v-model="valid" ref="form" lazy-validation @submit.prevent)
+      v-card-text
+        v-text-field(:value="currentUser.email" prepend-icon="email" label="current email" type="email" readonly)
+        v-text-field(v-model="newEmail" prepend-icon="email" label="new email" type="email" :rules="$rules.required")
+        v-text-field(v-model="currentPassword" prepend-icon="lock" label="current password" type="password" :rules="$rules.required")
+      v-card-actions
+        v-btn(type="submit" large color="primary" @click="changeEmail" :disabled="!valid || loading" :loading="loading") Submit
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+
+export default {
+  data() {
+    return {
+      currentPassword: '',
+      newEmail: '',
+      valid: false,
+      loading: false
+    }
+  },
+  computed: {
+    ...mapGetters('auth', ['currentUser']),
+    completedMessage() {
+      return 'Please access the authentication link in the confirmation email sent and complete the authentication.'
+    }
+  },
+  methods: {
+    ...mapActions('auth', { authUpdateEmail: 'updateEmail' }),
+    changeEmail() {
+      if (!this.$refs.form.validate()) {
+        return false
+      }
+
+      this.loading = true
+      this.authUpdateEmail({
+        currentPassword: this.currentPassword,
+        newEmail: this.newEmail
+      })
+        .then(() => {
+          this.$refs.form.reset()
+          this.$nextTick(() => {
+            this.currentPassword = ''
+            this.newEmail = ''
+          })
+          this.$emit('completed', this.completedMessage)
+        })
+        .catch(error => {
+          alert(error)
+        })
+        .finally(() => {
+          this.loading = false
+        })
+    }
+  }
+}
+</script>

--- a/components/SettingChangePassword.vue
+++ b/components/SettingChangePassword.vue
@@ -4,9 +4,9 @@
       v-toolbar-title Change Password
     v-form(v-model="valid" ref="form" lazy-validation @submit.prevent)
       v-card-text
-        v-text-field(v-model="passwordCurrent" prepend-icon="lock" label="current password" type="password" :rules="$rules.required")
-        v-password-field(v-model="passwordNew" label="new passowrd")
-        v-password-field(v-model="passwordConfirm" label="confirm new password" :confirm="passwordNew")
+        v-text-field(v-model="currentPassword" prepend-icon="lock" label="current password" type="password" :rules="$rules.required")
+        v-password-field(v-model="newPassword" label="new passowrd")
+        v-password-field(v-model="confirmPassword" label="confirm new password" :confirm="newPassword")
       v-card-actions
         v-btn(type="submit" large color="primary" @click="changePassword" :disabled="!valid || loading" :loading="loading") Submit
 </template>
@@ -17,9 +17,9 @@ import { mapActions } from 'vuex'
 export default {
   data() {
     return {
-      passwordCurrent: '',
-      passwordNew: '',
-      passwordConfirm: '',
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
       valid: false,
       loading: false
     }
@@ -33,15 +33,15 @@ export default {
 
       this.loading = true
       this.authUpdatePassword({
-        passwordCurrent: this.passwordCurrent,
-        passwordNew: this.passwordNew
+        currentPassword: this.currentPassword,
+        newPassword: this.newPassword
       })
         .then(() => {
           this.$refs.form.reset()
           this.$nextTick(() => {
-            this.passwordCurrent = ''
-            this.passwordNew = ''
-            this.passwordConfirm = ''
+            this.currentPassword = ''
+            this.newPassword = ''
+            this.confirmPassword = ''
           })
           this.$emit('completed', 'Password Changed.')
         })

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -2,6 +2,9 @@
   section
     v-container
       .display-2.primary--text.mb-3 Settings
+      v-layout(row wrap mb-4)
+        v-flex(xs12)
+          setting-change-email(@completed="completed")
       v-layout(row wrap)
         v-flex(xs12)
           setting-change-password(@completed="completed")
@@ -10,10 +13,12 @@
 </template>
 
 <script>
+import SettingChangeEmail from '~/components/SettingChangeEmail'
 import SettingChangePassword from '~/components/SettingChangePassword'
 
 export default {
   components: {
+    'setting-change-email': SettingChangeEmail,
     'setting-change-password': SettingChangePassword
   },
   data() {

--- a/store/auth.js
+++ b/store/auth.js
@@ -59,6 +59,16 @@ export const actions = {
       throw error
     }
   },
+  async updateEmail({ state, dispatch }, { currentPassword, newEmail }) {
+    try {
+      await dispatch('reauthenticate', currentPassword)
+      await state.user.updateEmail(newEmail)
+      await state.user.updateProfile({ displayName: newEmail })
+    } catch (error) {
+      console.error('reject[error]: ' + error)
+      throw error
+    }
+  },
   async updatePassword({ state, dispatch }, { passwordCurrent, passwordNew }) {
     try {
       await dispatch('reauthenticate', passwordCurrent)

--- a/store/auth.js
+++ b/store/auth.js
@@ -64,6 +64,7 @@ export const actions = {
       await dispatch('reauthenticate', currentPassword)
       await state.user.updateEmail(newEmail)
       await state.user.updateProfile({ displayName: newEmail })
+      await state.user.sendEmailVerification({ url: location.origin })
     } catch (error) {
       console.error('reject[error]: ' + error)
       throw error

--- a/store/auth.js
+++ b/store/auth.js
@@ -69,19 +69,19 @@ export const actions = {
       throw error
     }
   },
-  async updatePassword({ state, dispatch }, { passwordCurrent, passwordNew }) {
+  async updatePassword({ state, dispatch }, { currentPassword, newPassword }) {
     try {
-      await dispatch('reauthenticate', passwordCurrent)
-      await state.user.updatePassword(passwordNew)
+      await dispatch('reauthenticate', currentPassword)
+      await state.user.updatePassword(newPassword)
     } catch (error) {
       console.error('reject[error]: ' + error)
       throw error
     }
   },
-  reauthenticate({ state }, passwordCurrent) {
+  reauthenticate({ state }, currentPassword) {
     const credential = firebase.auth.EmailAuthProvider.credential(
       state.user.email,
-      passwordCurrent
+      currentPassword
     )
     return state.user.reauthenticateAndRetrieveDataWithCredential(credential)
   }


### PR DESCRIPTION
fix https://github.com/phayacell/fyi-stocker/issues/43

## やったこと

Settings ページにメールアドレス変更できる機能を追加する。
新しいメールアドレスを入力後、確認メールによる認証を経る。

## 備考

メールアドレスをアップデートしてから確認メールを飛ばしているので、確認メールによるチェックを済ませてからアップデートするようにしたい。
これは別 PR でやる。
