### PR TITLE
退会できるようにする

### DIFF
--- a/components/ContributeForm.vue
+++ b/components/ContributeForm.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
   v-card
-    v-form(v-if="contribute" ref="form" v-model="valid" lazy-validation @submit.prevent)
+    v-form(v-if="contribute" ref="form" v-model="valid" @submit.prevent)
       v-card-text
         v-text-field(v-model="contribute.at" prepend-icon="calendar_today" label="AT" :rules="$rules.required" required :disabled="loading")
         v-text-field(v-model="contribute.url" prepend-icon="link" label="URL" :rules="$rules.required" required :disabled="loading" @paste="loadTitle" autofocus)

--- a/components/SettingChangeEmail.vue
+++ b/components/SettingChangeEmail.vue
@@ -4,7 +4,7 @@
       v-toolbar-title Change Email
     v-form(v-model="valid" ref="form" lazy-validation @submit.prevent)
       v-card-text
-        v-text-field(:value="currentUser.email" prepend-icon="email" label="current email" type="email" readonly)
+        v-text-field(:value="currentEmail" prepend-icon="email" label="current email" type="email" readonly)
         v-text-field(v-model="newEmail" prepend-icon="email" label="new email" type="email" :rules="$rules.required")
         v-text-field(v-model="currentPassword" prepend-icon="lock" label="current password" type="password" :rules="$rules.required")
       v-card-actions
@@ -17,14 +17,18 @@ import { mapGetters, mapActions } from 'vuex'
 export default {
   data() {
     return {
-      currentPassword: '',
       newEmail: '',
+      currentPassword: '',
       valid: false,
       loading: false
     }
   },
   computed: {
     ...mapGetters('auth', ['currentUser']),
+    currentEmail() {
+      if (!this.currentUser) return ''
+      return this.currentUser.email
+    },
     completedMessage() {
       return 'Please access the authentication link in the confirmation email sent and complete the authentication.'
     }

--- a/components/SettingChangeEmail.vue
+++ b/components/SettingChangeEmail.vue
@@ -1,8 +1,8 @@
 <template lang="pug">
   v-card.elevation-1
     v-toolbar(dark flat color="primary")
-      v-toolbar-title Change Email
-    v-form(v-model="valid" ref="form" lazy-validation @submit.prevent)
+      v-toolbar-title Change email
+    v-form(v-model="valid" ref="form" @submit.prevent)
       v-card-text
         v-text-field(:value="currentEmail" prepend-icon="email" label="current email" type="email" readonly)
         v-text-field(v-model="newEmail" prepend-icon="email" label="new email" type="email" :rules="$rules.required")

--- a/components/SettingChangePassword.vue
+++ b/components/SettingChangePassword.vue
@@ -1,8 +1,8 @@
 <template lang="pug">
   v-card.elevation-1
     v-toolbar(dark flat color="primary")
-      v-toolbar-title Change Password
-    v-form(v-model="valid" ref="form" lazy-validation @submit.prevent)
+      v-toolbar-title Change password
+    v-form(v-model="valid" ref="form" @submit.prevent)
       v-card-text
         v-text-field(v-model="currentPassword" prepend-icon="lock" label="current password" type="password" :rules="$rules.required")
         v-password-field(v-model="newPassword" label="new passowrd")
@@ -43,7 +43,7 @@ export default {
             this.newPassword = ''
             this.confirmPassword = ''
           })
-          this.$emit('completed', 'Password Changed.')
+          this.$emit('completed', 'Password changed.')
         })
         .catch(error => {
           alert(error)

--- a/components/SettingDeleteAccount.vue
+++ b/components/SettingDeleteAccount.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   v-card.elevation-1
     v-toolbar(dark flat color="error")
-      v-toolbar-title Delete Account
+      v-toolbar-title Delete account
     v-form(v-model="valid" ref="form" @submit.prevent)
       v-card-text
         p.mb-4 Once you delete your account, there is no going back. Please be certain.

--- a/components/SettingDeleteAccount.vue
+++ b/components/SettingDeleteAccount.vue
@@ -1,0 +1,49 @@
+<template lang="pug">
+  v-card.elevation-1
+    v-toolbar(dark flat color="error")
+      v-toolbar-title Delete Account
+    v-form(v-model="valid" ref="form" @submit.prevent)
+      v-card-text
+        p.mb-4 Once you delete your account, there is no going back. Please be certain.
+        v-text-field(v-model="currentPassword" prepend-icon="lock" label="current password" type="password" :rules="$rules.required")
+      v-card-actions
+        v-btn(type="submit" large flat color="error" @click="deleteAccount" :disabled="!valid || loading" :loading="loading")
+          | Delete your account
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+
+export default {
+  data() {
+    return {
+      currentPassword: '',
+      valid: false,
+      loading: false
+    }
+  },
+  methods: {
+    ...mapActions('auth', {
+      authDeleteAccount: 'deleteAccount',
+      authSignOut: 'signOut'
+    }),
+    deleteAccount() {
+      if (!this.$refs.form.validate()) return false
+      if (!confirm('Are you sure you want to delete it?')) return false
+
+      this.loading = true
+      this.authDeleteAccount({ currentPassword: this.currentPassword })
+        .then(async () => {
+          await this.authSignOut()
+          await this.$router.push('/sign-in')
+        })
+        .catch(error => {
+          alert(error)
+        })
+        .finally(() => {
+          this.loading = false
+        })
+    }
+  }
+}
+</script>

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -5,9 +5,12 @@
       v-layout(row wrap mb-4)
         v-flex(xs12)
           setting-change-email(@completed="completed")
-      v-layout(row wrap)
+      v-layout(row wrap mb-4)
         v-flex(xs12)
           setting-change-password(@completed="completed")
+      v-layout(row wrap mb-4)
+        v-flex(xs12)
+          setting-delete-account(@completed="completed")
     v-snackbar(v-model="snackbar" bottom vertical dark color="success") {{ snackbarMessage }}
       v-btn(flat dark @click="snackbar = false") Close
 </template>
@@ -15,11 +18,13 @@
 <script>
 import SettingChangeEmail from '~/components/SettingChangeEmail'
 import SettingChangePassword from '~/components/SettingChangePassword'
+import SettingDeleteAccount from '~/components/SettingDeleteAccount'
 
 export default {
   components: {
     'setting-change-email': SettingChangeEmail,
-    'setting-change-password': SettingChangePassword
+    'setting-change-password': SettingChangePassword,
+    'setting-delete-account': SettingDeleteAccount
   },
   data() {
     return {

--- a/pages/sign-in/index.vue
+++ b/pages/sign-in/index.vue
@@ -6,7 +6,7 @@
           v-card.elevation-1
             v-toolbar(dark flat color="primary")
               v-toolbar-title Sign in form
-            v-form(v-model="valid" ref="form" lazy-validation @submit.prevent)
+            v-form(v-model="valid" ref="form" @submit.prevent)
               v-card-text
                 v-text-field(v-model="email" prepend-icon="email" label="email" type="email" :rules="$rules.required" autofocus)
                 v-password-field(v-model="password" label="password")

--- a/pages/sign-up/index.vue
+++ b/pages/sign-up/index.vue
@@ -6,7 +6,7 @@
           v-card.elevation-1
             v-toolbar(dark flat color="primary")
               v-toolbar-title Sign up form
-            v-form(v-model="valid" ref="form" lazy-validation @submit.prevent)
+            v-form(v-model="valid" ref="form" @submit.prevent)
               v-card-text
                 v-text-field(v-model="email" prepend-icon="email" label="email" type="email" :rules="$rules.required" autofocus)
                 v-password-field(v-model="password" label="password")

--- a/store/auth.js
+++ b/store/auth.js
@@ -79,6 +79,16 @@ export const actions = {
       throw error
     }
   },
+  async deleteAccount({ state, dispatch }, { currentPassword }) {
+    try {
+      await dispatch('reauthenticate', currentPassword)
+      await state.user.delete()
+      console.log('delete account')
+    } catch (error) {
+      console.error('reject[error]: ' + error)
+      throw error
+    }
+  },
   reauthenticate({ state }, currentPassword) {
     const credential = firebase.auth.EmailAuthProvider.credential(
       state.user.email,


### PR DESCRIPTION
fix https://github.com/phayacell/fyi-stocker/issues/44

## やったこと

![image](https://user-images.githubusercontent.com/12483929/74588244-0dec3600-503e-11ea-8571-c10cc229d1f5.png)

Delete account の実装。
一応、確認ダイアログも入れておいた。

ついでに、この実装にあたって他でも統一的にやっておきたいこともやっておいた。

- lazy-validation を止める
    - 入力していないのに submit ボタンが有効化されていたので
- 英語の大文字
    - 先頭でないのに大文字になっている箇所があったので
